### PR TITLE
📦 Ship both es6 and cjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,10 +2,11 @@
   "name": "@glideapps/tables",
   "version": "0.0.4",
   "description": "Client for Glide API",
-  "main": "dist/index.js",
+  "main": "dist/cjs/index.js",
+  "module": "dist/es6/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && tsc --build tsconfig.cjs.json",
     "test": "jest"
   },
   "author": "typeguard, Inc.",

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -1,0 +1,7 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "module": "commonjs",
+        "outDir": "dist/cjs"
+    }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
     "allowSyntheticDefaultImports": true,
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
-    "outDir": "dist",
+    "outDir": "dist/es6",
     "typeRoots": ["node_modules/@types"]
   },
   "include": ["src"]


### PR DESCRIPTION
Support question from Glide user:

> I'm developing a service outside of glide which interacts with the tables in our app using the "@glideapps/tables" package. I'm writing this using Typescript and whenever I try and compile my code using tsc I get an error related to your package. The error is that you cannot use import outside of an es6 module, and relates to the usage of "import fetch from "cross-fetch";" within your bundled code.


Asked them to provide their tsconfig.json

```
{
 "compilerOptions": {
  "target": "es2020",
  "module": "commonjs",
  "outDir": "./dist",
  "esModuleInterop": true,
  "forceConsistentCasingInFileNames": true,
  "skipLibCheck": true
 }
}
```

Using the above config I was not able to replicate in super simple example (maybe TS version diff?), however you will notice in our previous `dist/index.js` the compiled TS program is trying to `import` cross-fetch (vs require). 

This converts the default "main" entrypoint to common JS, but also provides the "module" package.json filed for tools that wish to use it. 

UPDATE:

The above report was mis-interpreted as a compiler issue, but it's a runtime issue that is easily reproduced trying to run a compiled version of TS code that uses this module:

```
benipsen ~/Developer/local/tables-debug  $ node dist/index.js
/Users/benipsen/Developer/glideapps/tables/dist/index.js:48
import fetch from "cross-fetch";
^^^^^^

SyntaxError: Cannot use import statement outside a module
``` 

I still think this PR might be a good solution, but exploring other options now.  
 

