### PR TITLE
Add configurability for external, internal use

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,3 +149,14 @@ const staging = new Glide({
   /* ... */
 });
 ```
+
+Or with the package:
+
+```ts
+import * as glide from "@glideapps/tables";
+
+const staging = glide.withConfig({
+  endpoint: "https://staging.heyglide.com/api/container",
+  /* ... */
+});
+```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@glideapps/tables",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "Client for Glide API",
   "main": "dist/cjs/index.js",
   "module": "dist/es6/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,5 +6,6 @@ export const app = defaultClient.app.bind(defaultClient);
 export const table = defaultClient.table.bind(defaultClient);
 export const getApps = defaultClient.getApps.bind(defaultClient);
 export const getAppNamed = defaultClient.getAppNamed.bind(defaultClient);
+export const withConfig = defaultClient.with.bind(defaultClient);
 
 export { RowOf, AppManifest } from "./types";


### PR DESCRIPTION
![20240223_145859](https://github.com/glideapps/tables/assets/512055/aad18d50-a8d2-4c4a-b424-89d825d47ec9)

When trying to use tables library (in glide-zapier-integration for example) trying to target staging system for tests, I can't configure this as an external library.

This gives external configurablity.