### PR TITLE
Use raw column name if we cannot resolve it when building a query

### DIFF
--- a/src/Table.ts
+++ b/src/Table.ts
@@ -276,7 +276,7 @@ export class Table<T extends ColumnSchema> {
     const sql = rowIDOrQuery?.(
       new QueryBuilder({
         table,
-        displayNameToName: name => this.displayNameToName[name],
+        displayNameToName: name => this.displayNameToName[name] ?? name,
       })
     ).toSQL();
 

--- a/src/Table.ts
+++ b/src/Table.ts
@@ -276,7 +276,7 @@ export class Table<T extends ColumnSchema> {
     const sql = rowIDOrQuery?.(
       new QueryBuilder({
         table,
-        displayNameToName: name => this.displayNameToName[name] ?? name,
+        displayNameToName: name => this.displayNameToName[name],
       })
     ).toSQL();
 


### PR DESCRIPTION
This allows queries to refer to column names that are not statically known.

We only do this for the lefthand side of the comparison; the righthand side can either be a column name, or a string literal, and we assume it's a string literal if the client does not recognize the column name. If instead we assumed that any unknown column was valid, we would have to change how queries comparing string literals are written.